### PR TITLE
Use get url

### DIFF
--- a/tasks/instance.yml
+++ b/tasks/instance.yml
@@ -24,6 +24,7 @@
     url: "{{ tomcat_unarchive_url }}"
     dest: "{{ tomcat_directory }}/{{ instance.name }}/tomcat_src.tar.gz"
     mode: 0440
+    validate_certs: "{{ tomcat_validate_certs }}"
 
 - name: install tomcat instance
   unarchive:

--- a/tasks/instance.yml
+++ b/tasks/instance.yml
@@ -79,3 +79,11 @@
     loop_var: war
   when:
     - instance.wars is defined
+
+- name: loop over libs
+  include: lib.yml
+  with_items: "{{ instance.libs }}"
+  loop_control:
+    loop_var: lib
+  when:
+    - instance.libs is defined

--- a/tasks/instance.yml
+++ b/tasks/instance.yml
@@ -19,9 +19,15 @@
     owner: "{{ instance.user | default(tomcat_user) }}"
     group: "{{ instance.group | default(tomcat_group) }}"
 
+- name: download tomcat source
+  get_url:
+    url: "{{ tomcat_unarchive_url }}"
+    dest: "{{ tomcat_directory }}/{{ instance.name }}/tomcat_src.tar.gz"
+    mode: 0440
+
 - name: install tomcat instance
   unarchive:
-    src: "{{ tomcat_unarchive_url }}"
+    src: "{{ tomcat_directory }}/{{ instance.name }}/tomcat_src.tar.gz"
     dest: "{{ tomcat_directory }}/{{ instance.name }}"
     owner: "{{ instance.user | default(tomcat_user) }}"
     group: "{{ instance.group | default(tomcat_group) }}"

--- a/tasks/lib.yml
+++ b/tasks/lib.yml
@@ -1,0 +1,10 @@
+---
+- name: deploy lib
+  get_url:
+    url: "{{ lib.url }}"
+    dest: "{{ tomcat_directory }}//{{ instance.name }}/lib/"
+    validate_certs: no
+  when:
+    - lib.url is defined
+  notify:
+    - restart tomcat instance

--- a/tasks/lib.yml
+++ b/tasks/lib.yml
@@ -3,7 +3,7 @@
   get_url:
     url: "{{ lib.url }}"
     dest: "{{ tomcat_directory }}//{{ instance.name }}/lib/"
-    validate_certs: no
+    validate_certs: "{{ tomcat_validate_certs }}"
   when:
     - lib.url is defined
   notify:


### PR DESCRIPTION
---
name: Pull request
about: Use get URL to download Tomcat archive

---

**Describe the change**
Unarchive does no use system PROXY and thuis breaks installation when you must use one.
get_url does use system proxy, so I splitted up download/unarchive in two parts so that unarchive refers to the downloaded archive from get_rul.

**Testing**
Just use the module as usual, there should not be any difference.
