### PR TITLE
fix for - Tomcat instance Service fails to start on CentOS 8

### DIFF
--- a/tasks/instance.yml
+++ b/tasks/instance.yml
@@ -83,7 +83,7 @@
     service_list:
       - name: "{{ instance.name | default(tomcat_name) }}"
         description: "{{ instance.name | default(tomcat_name) }}"
-        start_command: "{{ tomcat_directory }}/{{ instance.name | default(tomcat_directory) }}/bin/catalina.sh run"
+        start_command: "/bin/bash {{ tomcat_directory }}/{{ instance.name | default(tomcat_directory) }}/bin/catalina.sh run"
         user_name: "{{ instance.user | default(tomcat_user) }}"
         group_name: "{{ instance.group | default(tomcat_group) }}"
 

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -119,12 +119,13 @@
     <Connector port="{{ instance.ajp_port | default (tomcat_ajp_port) }}"
               address="{{ instance.address | default(tomcat_address) }}"
               protocol="AJP/1.3"
-              redirectPort="{{ instance.ssl_connector_port | default(tomcat_ssl_connector_port) }}" />
+              redirectPort="{{ instance.ssl_connector_port | default(tomcat_ssl_connector_port) }}"
 {% if instance.ajp_secret is defined %}
               secret="{{ instance.ajp_secret }}"
 {% else %}
               secretRequired="false"
 {% endif %}
+    />
 
     <!-- An Engine represents the entry point (within Catalina) that processes
          every request.  The Engine implementation for Tomcat stand alone


### PR DESCRIPTION
---
name: Pull request
about: minor bug fixes for [https://github.com/robertdebock/ansible-role-tomcat/issues/29](https://github.com/robertdebock/ansible-role-tomcat/issues/29)

---

**Describe the change**
  - using bin/bash to invoke the catalina.sh
  - fixed syntax issue with AJP attribute redirectPort being outside the tag.


**Testing**
Molecule tests already cover this change.
