### PR TITLE
CATALINA_OPTS in setenv.sh for example for remote jmx monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ This example is taken from `molecule/resources/converge.yml` and is tested on ea
         ajp_port: 8017
         libs:
           - url: "https://search.maven.org/remotecontent?filepath=io/prometheus/simpleclient/0.6.0/simpleclient-0.6.0.jar"
+      - name: "tomcat-with-jmx"
+        shutdown_port: 8023
+        non_ssl_connector_port: 8088
+        ssl_connector_port: 8450
+        ajp_port: 8017
+        catalina_opts: >-
+          -Dcom.sun.management.jmxremote.port=8375
+          -Dcom.sun.management.jmxremote.ssl=false
+          -Dcom.sun.management.jmxremote.authenticate=false
+          -Djava.rmi.server.hostname=jmx.1.1.1.10.nip.io          
       - name: "tomcat-access-logs"
         shutdown_port: 8024
         non_ssl_connector_port: 8089

--- a/tasks/instance.yml
+++ b/tasks/instance.yml
@@ -55,7 +55,7 @@
     dest: "{{ tomcat_directory }}/{{ instance.name }}/bin/setenv.sh"
     mode: "0644"
   when:
-    - (instance.java_opts is defined) or (instance.xms is defined) or (instance.xmx is defined)
+    - (instance.java_opts is defined) or (instance.xms is defined) or (instance.xmx is defined) or (instance.catalina_opts is defined)
   notify:
     - restart tomcat instance
 

--- a/templates/setenv.sh.j2
+++ b/templates/setenv.sh.j2
@@ -17,3 +17,7 @@ JAVA_OPTS="-Xms{{ instance.xms }} ${JAVA_OPTS}"
 {% else %}
 JAVA_OPTS="-Xms{{ tomcat_xms }} ${JAVA_OPTS}"
 {% endif %}
+
+{% if instance.catalina_opts is defined %}
+CATALINA_OPTS="{{ instance.catalina_opts }}"
+{% endif %}


### PR DESCRIPTION
---
name: Pull request
about: CATALINA_OPTS in setenv.sh

---

**Describe the change**
Allow CATALINA_OPTS to be configured. This allows all kinds of configuration of Tomcat to occur for example JMX remote monitoring

**Testing**
Manual test of JMX remote monitoring using JConsole and VisualVM of tomcat instance. 
