### PR TITLE
Increase default packet size set by application

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,7 @@ tomcat_instances:
     ajp_secret: ""
     # You can pick an address per instance:
     # address: 127.0.0.1
+    packet_size: ""
     java_opts:
       - name: JRE_HOME
         value: "{{ tomcat_jre_home }}"

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -125,6 +125,9 @@
 {% else %}
               secretRequired="false"
 {% endif %}
+{% if instance.packet_size is defined %}
+	      packetSize="{{ instance.packet_size }}"
+{% endif %}
     />
 
     <!-- An Engine represents the entry point (within Catalina) that processes


### PR DESCRIPTION
name: ajp_packet_size
about: Getting errors when the overall size of cookies set by the application become more than 8K (which is the default value for mod_jk and tomcat)

I would like to propose a change, to increase the packet size limit if necessary.

