### PR TITLE
Feature: Make AJP Connector optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ tomcat_non_ssl_connector_port: 8080
 tomcat_ssl_connector_port: 8443
 tomcat_shutdown_port: 8005
 tomcat_shutdown_pass: SHUTDOWN
+tomcat_ajp_enabled: yes
 tomcat_ajp_port: 8009
 tomcat_jre_home: /usr
 tomcat_service_state: started
@@ -162,6 +163,7 @@ tomcat_instances:
     non_ssl_connector_port: "{{ tomcat_non_ssl_connector_port }}"
     ssl_connector_port: "{{ tomcat_ssl_connector_port }}"
     shutdown_port: "{{ tomcat_shutdown_port }}"
+    ajp_enabled: "{{ tomcat_ajp_enabled }}"
     ajp_port: "{{ tomcat_ajp_port }}"
     ajp_secret: ""
     # You can pick an address per instance:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ tomcat_non_ssl_connector_port: 8080
 tomcat_ssl_connector_port: 8443
 tomcat_shutdown_port: 8005
 tomcat_shutdown_pass: SHUTDOWN
+tomcat_ajp_enabled: yes
 tomcat_ajp_port: 8009
 tomcat_jre_home: /usr
 tomcat_service_state: started
@@ -45,6 +46,7 @@ tomcat_instances:
     non_ssl_connector_port: "{{ tomcat_non_ssl_connector_port }}"
     ssl_connector_port: "{{ tomcat_ssl_connector_port }}"
     shutdown_port: "{{ tomcat_shutdown_port }}"
+    ajp_enabled: "{{ tomcat_ajp_enabled }}"
     ajp_port: "{{ tomcat_ajp_port }}"
     ajp_secret: ""
     # You can pick an address per instance:

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -83,7 +83,7 @@
     that:
       - tomcat_non_ssl_connector_port is defined
       - tomcat_non_ssl_connector_port is number
-      - tomcat_non_ssl_connector_port > 0
+      - tomcat_non_ssl_connector_port >= -1
       - tomcat_non_ssl_connector_port < 65536
     quiet: yes
 
@@ -92,7 +92,7 @@
     that:
       - tomcat_ssl_connector_port is defined
       - tomcat_ssl_connector_port is number
-      - tomcat_ssl_connector_port > 0
+      - tomcat_ssl_connector_port >= -1
       - tomcat_ssl_connector_port < 65536
     quiet: yes
 
@@ -101,7 +101,7 @@
     that:
       - tomcat_shutdown_port is defined
       - tomcat_shutdown_port is number
-      - tomcat_shutdown_port > 0
+      - tomcat_shutdown_port >= -1
       - tomcat_shutdown_port < 65536
     quiet: yes
 
@@ -117,7 +117,7 @@
     that:
       - tomcat_ajp_port is defined
       - tomcat_ajp_port is number
-      - tomcat_ajp_port > 0
+      - tomcat_ajp_port >= -1
       - tomcat_ajp_port < 65536
     quiet: yes
 
@@ -237,7 +237,7 @@
   ansible.builtin.assert:
     that:
       - item.non_ssl_connector_port is number
-      - item.non_ssl_connector_port > 0
+      - item.non_ssl_connector_port >= -1
       - item.non_ssl_connector_port < 65536
     quiet: yes
   loop: "{{ tomcat_instances }}"
@@ -250,7 +250,7 @@
   ansible.builtin.assert:
     that:
       - item.ssl_connector_port is number
-      - item.ssl_connector_port > 0
+      - item.ssl_connector_port >= -1
       - item.ssl_connector_port < 65536
     quiet: yes
   loop: "{{ tomcat_instances }}"
@@ -263,7 +263,7 @@
   ansible.builtin.assert:
     that:
       - item.shutdown_port is number
-      - item.shutdown_port > 0
+      - item.shutdown_port >= -1
       - item.shutdown_port < 65536
     quiet: yes
   loop: "{{ tomcat_instances }}"
@@ -287,7 +287,7 @@
   ansible.builtin.assert:
     that:
       - item.ajp_port is number
-      - item.ajp_port > 0
+      - item.ajp_port >= -1
       - item.ajp_port < 65536
     quiet: yes
   loop: "{{ tomcat_instances }}"

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -105,6 +105,13 @@
       - tomcat_shutdown_port < 65536
     quiet: yes
 
+- name: test if tomcat_ajp_enabled is set correctly
+  ansible.builtin.assert:
+    that:
+      - tomcat_ajp_enabled is defined
+      - tomcat_ajp_enabled is boolean
+    quiet: yes
+
 - name: test if tomcat_ajp_port is set correctly
   ansible.builtin.assert:
     that:
@@ -264,6 +271,17 @@
     label: "{{ item.name }}"
   when:
     - item.shutdown_port is defined
+
+- name: test if item.ajp_enabled in tomcat_instances is set correctly
+  ansible.builtin.assert:
+    that:
+      - item.ajp_enabled is boolean
+    quiet: yes
+  loop: "{{ tomcat_instances }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - item.ajp_enabled is defined
 
 - name: test if item.ajp_port in tomcat_instances is set correctly
   ansible.builtin.assert:

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -115,6 +115,7 @@
     </Connector>
     -->
 
+{% if instance.ajp_enabled | default(tomcat_ajp_enabled) %}
     <!-- Define an AJP 1.3 Connector on port 8009 -->
     <Connector port="{{ instance.ajp_port | default (tomcat_ajp_port) }}"
               address="{{ instance.address | default(tomcat_address) }}"
@@ -129,6 +130,7 @@
 	      packetSize="{{ instance.packet_size }}"
 {% endif %}
     />
+{% endif %}
 
     <!-- An Engine represents the entry point (within Catalina) that processes
          every request.  The Engine implementation for Tomcat stand alone


### PR DESCRIPTION
---
name: Pull request
about: Make the AJP Connector optional

---

**Describe the change**
Added two new flags that allow to disable AJP connector on global or instance level. 

**Testing**
Changes were tested in our local environment