### PR TITLE
Fix condition for ajp_secret

### DIFF
--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -121,7 +121,7 @@
               address="{{ instance.address | default(tomcat_address) }}"
               protocol="AJP/1.3"
               redirectPort="{{ instance.ssl_connector_port | default(tomcat_ssl_connector_port) }}"
-{% if instance.ajp_secret is defined %}
+{% if instance.ajp_secret is defined and instance.ajp_secret | length > 0 %}
               secret="{{ instance.ajp_secret }}"
 {% else %}
               secretRequired="false"


### PR DESCRIPTION
Currently ajp_secret default is an empty string which will result in
condition to be true even when no secret is defined
Tomcat will fail to start because secret can't be empty

Closes-Bug: #42
Signed-Off-By: Dmitriy Rabotyagov <noonedeadpunk@ya.ru>
