### PR TITLE
packet_size doesn't need quotes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,7 +52,7 @@ tomcat_instances:
     ajp_secret: "{{ tomcat_ajp_secret }}"
     # You can pick an address per instance:
     # address: 127.0.0.1
-    packet_size: "8192"
+    packet_size: 8192
     java_opts:
       - name: JRE_HOME
         value: "{{ tomcat_jre_home }}"


### PR DESCRIPTION
---
name: Pull request
about: remove quotes in packet_size

---

**Describe the change**
 is number assertion was failling for packet_size 
TASK [robertdebock.tomcat : test if item.packet_size in tomcat_instances is set correctly] ***
... "Assertion failed"}
With ansible_core 2.11

**Testing**
In case a feature was added, how were tests performed?
The role was called in a molecule test of mine.