### PR TITLE
Compare tar ball checksum to allow tomcat upgrades

### DIFF
--- a/tasks/instance.yml
+++ b/tasks/instance.yml
@@ -20,11 +20,36 @@
     group: "{{ instance.group | default(tomcat_group) }}"
     mode: "0755"
 
+- name: Get sha1sum of existing tomcat source
+  ansible.builtin.stat:
+    path: "{{ tomcat_directory }}/{{ instance.name }}/tomcat_src.tar.gz"
+    checksum_algorithm: sha1
+    get_checksum: yes
+  register: sha_existing
+
+- name: Remove existing tomcat source
+  ansible.builtin.file:
+    path: "{{ tomcat_directory }}/{{ instance.name }}/tomcat_src.tar.gz"
+    state: absent
+
 - name: download tomcat source
   ansible.builtin.get_url:
     url: "{{ tomcat_unarchive_url }}"
     dest: "{{ tomcat_directory }}/{{ instance.name }}/tomcat_src.tar.gz"
     mode: "440"
+
+- name: Get sha1sum of downloaded tomcat source
+  ansible.builtin.stat:
+    path: "{{ tomcat_directory }}/{{ instance.name }}/tomcat_src.tar.gz"
+    checksum_algorithm: sha1
+    get_checksum: yes
+  register: sha_new
+
+- name: If checksums are different, then remove bin and extract
+  ansible.builtin.file:
+    path: "{{ tomcat_directory }}/{{ instance.name }}/bin"
+    state: absent
+  when: (not sha_existing.stat.checksum is defined) or (sha_existing.stat.checksum != sha_new.stat.checksum)
 
 - name: install tomcat instance
   ansible.builtin.unarchive:


### PR DESCRIPTION
---
name: Pull request
about: This is related to #22 and allows the tomcat role to verify if a newer version was downloaded and upgrade the instance.

---

**Describe the change**
Calculate the sha1 of the tomcat tarball and verify it with the sha1 of the freshly downloaded tarball. If there is a difference the instance bin folder gets removed to trigger the extracting of the new tarball

**Testing**
Manually tested playbook with:
- Fresh install - Tomcat installed ✅ 
- Re-run against same tomcat version - No change performed ✅ 
- Re-Run with newer tomcat version - Upgrade installed ✅ 
- Re-Run with older tomcat version - Downgraded version installed ✅ 