### PR TITLE
feat(server_xml): adding log maxDays fileDateFormat

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,8 @@ tomcat_access_log_directory: logs
 tomcat_access_log_prefix: localhost_access_log
 tomcat_access_log_suffix: ".txt"
 tomcat_access_log_pattern: "%h %l %u %t &quot;%r&quot; %s %b"
+tomcat_access_log_max_days: "1"
+tomcat_access_log_file_date_format: ".yyyy-MM-dd.HH"
 
 # This role allows multiple installations of Apache Tomcat, each in their own
 # location, potentially of different version.
@@ -61,6 +63,8 @@ tomcat_instances:
     access_log_prefix: "{{ tomcat_access_log_prefix }}"
     access_log_suffix: "{{ tomcat_access_log_suffix }}"
     access_log_pattern: "{{ tomcat_access_log_pattern }}"
+    access_log_max_days: "{{ tomcat_access_log_max_days }}"
+    access_log_file_date_format: "{{ tomcat_access_log_date_format }}"
     service_state: "{{ tomcat_service_state }}"
     service_enabled: "{{ tomcat_service_enabled }}"
 

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -176,6 +176,8 @@
 {% if instance.access_log_enabled | default(tomcat_access_log_enabled) %}
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="{{ instance.access_log_directory | default(tomcat_access_log_directory) }}"
                prefix="{{ instance.access_log_prefix | default(tomcat_access_log_prefix) }}" suffix="{{ instance.access_log_suffix | default(tomcat_access_log_suffix) }}"
+               fileDateFormat="{{ instance.access_log_file_date_format | default(tomcat_access_log_file_date_format) }}"
+               maxDays="{{ instance.access_log_max_days | default(tomcat_access_log_max_days) }}"
                pattern="{{ instance.access_log_pattern | default(tomcat_access_log_pattern) }}" />
 {% endif %}
 


### PR DESCRIPTION
Adding some server.xml changes:
  - maxDays: The maximum number of days rotated access logs will be retained for before being deleted
  - fileDateFormat: Allows a customized timestamp in the access log file name


