### PR TITLE
feat: add tomcat 11 support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 # Some "sane" defaults.
 tomcat_name: tomcat
 tomcat_directory: /opt
-tomcat_version: 10
+tomcat_version: 11
 tomcat_user: tomcat
 tomcat_group: tomcat
 tomcat_xms: 512M
@@ -69,6 +69,7 @@ tomcat_version7: "7.0.109"
 tomcat_version8: "8.5.100"
 tomcat_version9: "9.0.100"
 tomcat_version10: "10.1.36"
+tomcat_version11: "11.0.8"
 
 # The location where to download Apache Tomcat from.
 tomcat_mirror: "https://archive.apache.org"

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -29,7 +29,7 @@
     that:
       - tomcat_version is defined
       - tomcat_version is number
-      - tomcat_version in [ 7, 8, 9, 10 ]
+      - tomcat_version in [ 7, 8, 9, 10, 11 ]
     quiet: true
 
 - name: assert | Test tomcat_user

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,5 +9,6 @@ _tomcat_unarchive_urls:
   8: "{{ tomcat_mirror }}/dist/tomcat/tomcat-8/v{{ tomcat_version8 }}/bin/apache-tomcat-{{ tomcat_version8 }}.tar.gz"
   9: "{{ tomcat_mirror }}/dist/tomcat/tomcat-9/v{{ tomcat_version9 }}/bin/apache-tomcat-{{ tomcat_version9 }}.tar.gz"
   10: "{{ tomcat_mirror }}/dist/tomcat/tomcat-10/v{{ tomcat_version10 }}/bin/apache-tomcat-{{ tomcat_version10 }}.tar.gz"
+  11: "{{ tomcat_mirror }}/dist/tomcat/tomcat-11/v{{ tomcat_version11 }}/bin/apache-tomcat-{{ tomcat_version11 }}.tar.gz"
 
 tomcat_unarchive_url: "{{ _tomcat_unarchive_urls[instance.version | default(tomcat_version)] }}"


### PR DESCRIPTION

**Describe the change**

Add support for the current Tomcat 11 version and set it as new default version

**Testing**

Besides the molecule test, I also did a manual test on Ubuntu:

* Installed on an ubuntu 22.04 and 24.04
* Installed the tomcat 11 sample apps.

Result: Worked without any issues or errors in the logs.



